### PR TITLE
Fix: Compile Error in macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,17 @@
 *.zip
 x86
 x64
+
+# ignore output files
+gust_ebm
+gust_elixir
+gust_enc
+gust_g1t
+gust_gmpk
+gust_pak
+gust_ebm.exe
+gust_elixir.exe
+gust_enc.exe
+gust_g1t.exe
+gust_gmpk.exe
+gust_pak.exe

--- a/gust_ebm.c
+++ b/gust_ebm.c
@@ -97,7 +97,7 @@ int main_utf8(int argc, char** argv)
         uint32_t ebm_header[11];
         assert(array_size(ebm_header) >= 9 + duration1_length[array_size(duration1_length) - 1]);
         assert(array_size(ebm_header) >= duration2_length[array_size(duration2_length) - 1]);
-        for (size_t i = 0; i < abs(nb_messages); i++) {
+        for (size_t i = 0; i < (size_t)abs(nb_messages); i++) {
             JSON_Object* json_message = json_array_get_object(json_messages, i);
             memset(ebm_header, 0, sizeof(ebm_header));
             uint32_t j = 0;
@@ -159,7 +159,7 @@ int main_utf8(int argc, char** argv)
             for (d2 = 0; d2 < array_size(duration2_length); d2++) {
                 uint32_t* p = (uint32_t*)&buf[sizeof(uint32_t)];
                 bool good_candidate = true;
-                for (size_t i = 0; i < abs(nb_messages) && good_candidate; i++) {
+                for (size_t i = 0; i < (size_t)abs(nb_messages) && good_candidate; i++) {
                     uint32_t len = p[8 + duration1_length[d1]];
                     good_candidate = (len != 0 && len <= MAX_STRING_SIZE);
                     if (!good_candidate)
@@ -189,7 +189,7 @@ detected:
         json_object_set_number(json_object(json), "nb_messages", nb_messages & 0xffffffff);
         json_messages = json_value_init_array();
         uint32_t* ebm_header = (uint32_t*)&buf[sizeof(uint32_t)];
-        for (size_t i = 0; i < abs(nb_messages); i++) {
+        for (size_t i = 0; i < (size_t)abs(nb_messages); i++) {
             uint32_t j = 0;
             json_message = json_value_init_object();
             json_object_set_number(json_object(json_message), "type", (double)ebm_header[j]);

--- a/gust_elixir.c
+++ b/gust_elixir.c
@@ -207,7 +207,7 @@ int main_utf8(int argc, char** argv)
 
         if (json_object_get_boolean(json_object(json), "compressed")) {
             printf("Compressing...\n");
-            compressor = calloc(1, sizeof(tdefl_compressor));
+            compressor = (tdefl_compressor*)calloc(1, sizeof(tdefl_compressor));
             if (compressor == NULL)
                 goto out;
             dst = fopen_utf8(filename, "wb");
@@ -216,8 +216,8 @@ int main_utf8(int argc, char** argv)
                 goto out;
             }
             fseek(file, 0, SEEK_SET);
-            buf = malloc(DEFAULT_CHUNK_SIZE);
-            zbuf = malloc(DEFAULT_CHUNK_SIZE);
+            buf = (uint8_t*)malloc(DEFAULT_CHUNK_SIZE);
+            zbuf = (uint8_t*)malloc(DEFAULT_CHUNK_SIZE);
             while (1) {
                 size_t written = DEFAULT_CHUNK_SIZE;
                 size_t read = fread(buf, 1, DEFAULT_CHUNK_SIZE, file);
@@ -285,7 +285,7 @@ int main_utf8(int argc, char** argv)
 
         if (gz_pos != NULL) {
             file_size *= 2;
-            buf = malloc(file_size);
+            buf = (uint8_t *)malloc(file_size);
             if (buf == NULL)
                 goto out;
             size_t pos = 0;
@@ -298,7 +298,7 @@ int main_utf8(int argc, char** argv)
                 }
                 if (zsize == 0)
                     break;
-                zbuf = malloc(zsize);
+                zbuf = (uint8_t*)malloc(zsize);
                 if (zbuf == NULL)
                     goto out;
                 if (fread(zbuf, 1, zsize, file) != zsize) {
@@ -310,7 +310,7 @@ increase_buf_size:
                 if ((s == -2) || (pos + DEFAULT_CHUNK_SIZE > file_size)) {
                     file_size *= 2;
                     uint8_t* old_buf = buf;
-                    buf = realloc(buf, file_size);
+                    buf = (uint8_t *)realloc(buf, file_size);
                     if (buf == NULL) {
                         fprintf(stderr, "ERROR: Can't increase buffer size\n");
                         buf = old_buf;
@@ -347,7 +347,7 @@ increase_buf_size:
                 goto out;
             }
         } else {
-            buf = malloc(file_size);
+            buf = (uint8_t*)malloc(file_size);
             if (buf == NULL)
                 goto out;
             if (fread(buf, 1, file_size, file) != file_size) {
@@ -398,7 +398,7 @@ increase_buf_size:
         for (uint32_t i = 0; i < hdr->nb_files; i++) {
             lxr_entry* entry = (lxr_entry*)&buf[sizeof(lxr_header) + (size_t)i * lxr_entry_size];
             assert(entry->offset + entry->size <= (uint32_t)file_size);
-            char* filename = calloc(0x20 + hdr->filename_size * 0x10 + 1, 1);
+            char* filename = (char*)calloc(0x20 + hdr->filename_size * 0x10 + 1, 1);
             if (filename == NULL)
                 goto out;
             memcpy(filename, entry->filename, 0x20 + hdr->filename_size * 0x10);

--- a/gust_pak.c
+++ b/gust_pak.c
@@ -430,7 +430,7 @@ int main_utf8(int argc, char** argv)
                 goto out;
             }
             fseek64(file, entry(i, data_offset) + file_data_offset, SEEK_SET);
-            buf = malloc(entry(i, size));
+            buf = (uint8_t*)malloc(entry(i, size));
             if (buf == NULL) {
                 fprintf(stderr, "ERROR: Can't allocate entries\n");
                 goto out;

--- a/util.c
+++ b/util.c
@@ -49,7 +49,7 @@ bool create_path(char* path)
         if (pos > 0) {
             // Create parent dirs
             path[pos] = 0;
-            char* new_path = malloc(strlen(path) + 1);
+            char* new_path = (char*)malloc(strlen(path) + 1);
             if (new_path == NULL) {
                 fprintf(stderr, "ERROR: Can't allocate path\n");
                 return false;
@@ -182,7 +182,7 @@ uint32_t read_file_max(const char* path, uint8_t** buf, uint32_t max_size)
     if (max_size != 0)
         size = min(size, max_size);
 
-    *buf = calloc(size, 1);
+    *buf = (uint8_t*)calloc(size, 1);
     if (*buf == NULL) {
         size = UINT32_MAX;
         goto out;
@@ -218,7 +218,7 @@ void create_backup(const char* path)
 {
     struct stat64_t st;
     if (stat64_utf8(path, &st) == 0) {
-        char* backup_path = malloc(strlen(path) + 5);
+        char* backup_path = (char*)malloc(strlen(path) + 5);
         if (backup_path == NULL)
             return;
         strcpy(backup_path, path);


### PR DESCRIPTION
The project can't be compiled due to type errors in macOS.

![image](https://github.com/VitaSmith/gust_tools/assets/5810331/dbcb067c-bc4d-472d-adb6-41fdcf406611)


```console
$ clang --version
Apple clang version 13.0.0 (clang-1300.0.29.30)
Target: x86_64-apple-darwin23.4.0
Thread model: posix
```

This updated version is verified in both Intel and Apple silicon.